### PR TITLE
Verify X-Hub-Signature header if GITHUB_X_HUB_SIGNATURE_SECRET is set

### DIFF
--- a/lib/puppet_labs/pull_request_app.rb
+++ b/lib/puppet_labs/pull_request_app.rb
@@ -4,12 +4,27 @@ require 'sinatra/base'
 require 'puppet_labs/pull_request'
 require 'puppet_labs/pull_request_job'
 require 'delayed_job_active_record'
+require 'openssl'
+require 'digest/sha1'
 require 'workless'
 
 
 module PuppetLabs
   class PullRequestApp < Sinatra::Base
+    HMAC_DIGEST = OpenSSL::Digest::Digest.new('sha1')
+
+    class UnauthenticatedError < StandardError; end
+
+    use Rack::Logger
+
+    helpers do
+      def logger
+        request.logger
+      end
+    end
+
     configure :production do
+      disable :show_exceptions
       Delayed::Worker.max_attempts = 3
       Delayed::Backend::ActiveRecord::Job.send(:include, Delayed::Workless::Scaler)
       Delayed::Job.scaler = :heroku_cedar
@@ -20,7 +35,34 @@ module PuppetLabs
     end
 
     post '/event/pull_request' do
-      pull_request = PuppetLabs::PullRequest.from_json(request['payload'])
+      headers = {'Content-Type' => 'application/json'}
+      my_body = request.body.read
+
+      # Authenticate via X-Hub-Signature
+      # TODO: This could be a Sinatra filter.  See:
+      # http://sinatra.restafari.org/book.html#authentication
+      if !(secret = ENV['GITHUB_X_HUB_SIGNATURE_SECRET'].to_s).empty?
+        # The computed SHA1 signature.  This should match the header value.
+        sig_c = "sha1=#{OpenSSL::HMAC.hexdigest(HMAC_DIGEST, secret, my_body)}".downcase
+        # The sent SHA1 sinagure.  Expected in the X-Hub-Signature request header.
+        sig_s = env['HTTP_X_HUB_SIGNATURE'].to_s.downcase
+        if sig_c != sig_s
+          body = {
+            'message' => 'Permission denied. X-Hub-Signature header does not match body'
+          }
+          halt 401, headers, JSON.dump(body)
+        end
+      end
+
+      # If there is form data then we expect the payload in the payload parameter.
+      # otherwise, we expect all of the form data on the in
+      payload = if request.form_data?
+        request['payload']
+      else
+        my_body
+      end
+
+      pull_request = PuppetLabs::PullRequest.from_json(payload)
       job = PuppetLabs::PullRequestJob.new
       job.pull_request = pull_request
       delayed_job = job.queue
@@ -30,7 +72,6 @@ module PuppetLabs
       # not been completed. The request might or might not eventually be acted
       # upon, as it might be disallowed when processing actually takes place.
       status = 202
-      headers = {'Content-Type' => 'application/json'}
       body = {
         'job_id' => delayed_job.id,
         'queue' => delayed_job.queue,


### PR DESCRIPTION
Without this patch we have no way to authenticate requests are actually
coming from Github or not.  This patch addresses the problem by checking
the digital signature contained in the X-Hub-Signature header.

Github will use the sha1 HMAC to produce a signature from a shared
secret if the data['secret'] key contains some string.  See:
https://github.com/github/github-services/blob/master/services/web.rb#L48

This patch configures the web app to authenticate requests if the Heroku
configuration key named GITHUB_X_HUB_SIGNATURE_SECRET contains a secret
key.  Both configuration settings should match for authenticated
requests to work as expected.

This patch also changes the preferred webhook content type to be JSON.
When configuring the hooks on Github, specifying the "content_type":
"json" setting in the config section will cause the requests to contain
pure JSON in the body instead of in the 'payload' parameter of the
multipart form data.

This enables streaming of the JSON POST request.

Finally, the preferred transport is https instead of http.  Heroku
provides a valid SSL certificate for all of their applications.
