### PR TITLE
Only act when a pull request is opened

### DIFF
--- a/lib/puppet_labs/pull_request.rb
+++ b/lib/puppet_labs/pull_request.rb
@@ -3,38 +3,32 @@ require 'json'
 # This class provides a model of a pull rquest.
 module PuppetLabs
 class PullRequest
-  attr_accessor :json
-  attr_reader :data
   # Pull request data
-  attr_reader :number, :repo_name, :title, :html_url, :body
+  attr_reader :number,
+    :repo_name,
+    :title,
+    :html_url,
+    :body,
+    :action
 
   def self.from_json(json)
     new(:json => json)
   end
 
   def initialize(options = {})
-    if @json = options[:json]
-      load_json
+    if json = options[:json]
+      load_json(json)
     end
   end
 
-  ##
-  # load_json parses the JSON data stored in @json and stores the result in
-  # @data
-  def load_json
-    if data = JSON.load(@json)
-      @data = data
-      refresh_data
-    end
+  def load_json(json)
+    data = JSON.load(json)
+    @number = data['pull_request']['number']
+    @title = data['pull_request']['title']
+    @html_url = data['pull_request']['html_url']
+    @body = data['pull_request']['body']
+    @repo_name = data['repository']['name']
+    @action = data['action']
   end
-
-  def refresh_data
-    @number = @data['pull_request']['number']
-    @title = @data['pull_request']['title']
-    @html_url = @data['pull_request']['html_url']
-    @body = @data['pull_request']['body']
-    @repo_name = @data['repository']['name']
-  end
-  private :refresh_data
 end
 end

--- a/spec/unit/puppet_labs/pull_request_spec.rb
+++ b/spec/unit/puppet_labs/pull_request_spec.rb
@@ -8,26 +8,33 @@ describe 'PuppetLabs::PullRequest' do
 
   it 'creates a new instance using the from_json class method' do
     pr = PuppetLabs::PullRequest.from_json(payload)
-    pr.json.should == payload
-  end
-
-  it 'accepts json' do
-    subject.json = payload
-    subject.json.should == payload
   end
 
   it 'initializes with json' do
     pr = PuppetLabs::PullRequest.new(:json => payload)
-    pr.data.should == data
+    pr.action.should == "opened"
   end
 
   describe '#load_json' do
-    before :each do
-      subject.json = payload
-    end
     it 'loads a json hash readable through the data method' do
-      subject.load_json
-      subject.data.should == data
+      subject.load_json(payload)
+      subject.action.should == "opened"
+    end
+  end
+
+  describe "#action" do
+    actions = [ "opened", "closed", "synchronize" ]
+    payloads = [
+      read_fixture("example_pull_request.json"),
+      read_fixture("example_pull_request_closed.json"),
+      read_fixture("example_pull_request_synchronize.json"),
+    ]
+
+    actions.zip(payloads).each do |action, payload|
+      it "returns '#{action}' when the pull request is #{action}." do
+        subject.load_json(payload)
+        subject.action.should == action
+      end
     end
   end
 


### PR DESCRIPTION
Without this patch the hook will create a card that does not exist or is
archived when any pull request event is received from Github.  This is a
problem because pull requests that are closed or synchronized should not
re-create cards that have been moved.

This patch addresses the problem by having the Sinatra web application
check the JSON payload and only queue the pull request job if the event
action is "opened"
