### PR TITLE
Make logging work in Heroku using STDERR

### DIFF
--- a/lib/puppet_labs/pull_request_job.rb
+++ b/lib/puppet_labs/pull_request_job.rb
@@ -1,5 +1,6 @@
 require 'puppet_labs/pull_request'
 require 'puppet_labs/sinatra_dj'
+require 'logger'
 require 'trello'
 
 module PuppetLabs
@@ -14,7 +15,6 @@ class PullRequestJob
   attr_reader :list_id, :key, :secret, :token
   attr_accessor :pull_request
   attr_writer :env
-
 
   def card_body
     pr = pull_request
@@ -93,9 +93,11 @@ class PullRequestJob
   end
   private :trello_api
 
+  ##
+  # display simply sends text to standard output for use in Heroku.
   def display(text)
-    Delayed::Worker.logger ||= Logger.new(STDOUT)
-    Delayed::Worker.logger.add(Logger::INFO, text)
+    @log ||= Logger.new(STDERR)
+    @log.info text
   end
   private :display
 end


### PR DESCRIPTION
Without this patch none of the logging generated by the Sinatra
application or the Delayed Job are showing up in the output of `heroku
logs`.  This is a problem because we need to be able to see what's
happening with the application and the job processing.  The core problem
is that logs in Heroku are captured off the STDOUT and STDERR streams,
while the default logging for Active Record goes to a file on disk.

This patch addresses the problem by logging to STDOUT which should be
caught by Heroku.
