### PR TITLE
Disable email notifications from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: ruby
 bundler_args: --without development
 script: "bundle exec rake spec"
+notifications:
+  email: false
 rvm:
   - 1.9.3
   - ruby-head


### PR DESCRIPTION
Without this patch TravisCI will email email the following people:

By default it will send emails to the commit author and committer, the
owner of the repository (for normal repositories), and all public
members of the organization owning the repository.

More information at: http://about.travis-ci.org/docs/user/notifications/

This patch disables email entirely.  If we need notifications of build
failures we'll likely use webhooks.
