### PR TITLE
Handle Travis CI Events at /event/travis_ci

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 doc/
 log/
 setup.env
+.bundle/
+vendor/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,15 @@
 language: ruby
 bundler_args: --without development
 script: "bundle exec rake spec"
-notifications:
-  email: false
 rvm:
   - 1.9.3
   - ruby-head
   - 1.8.7
+notifications:
+  email: false
+  webhooks:
+    urls:
+      - https://puppet-dev-community.herokuapp.com/event/travis_ci/
+    on_success: always
+    on_failure: always
+    on_start: true


### PR DESCRIPTION
Without this patch we have no facility to receive and handle events
generated by the Travis CI webhook.  This patch lays the groundwork,
performing authentication of the request made by TravisCI.

The relevant configuration for participating repositories is:

```
notifications:
email: false
webhooks:
  urls:
    - https://puppet-dev-community.herokuapp.com/event/travis_ci/
  on_success: always
  on_failure: always
  on_start: true
```

Webhook notification documentation is available at:
http://about.travis-ci.org/docs/user/notifications/#Webhook-notification
