### PR TITLE
Add Apache 2.0 License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,15 @@
+   Copyright (C) 2005-2012 Puppet Labs Inc
+
+   Puppet Labs can be contacted at: info@puppetlabs.com
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -333,4 +333,9 @@ Jeff McCune <jeff@puppetlabs.com>
 [dashboard]: https://dashboard.heroku.com/apps
 [quickstart]: https://devcenter.heroku.com/articles/quickstart
 
+License
+====
+
+Apache 2.0.  Please see the LICENSE file for more information.
+
 EOF


### PR DESCRIPTION
Without this patch the license of this software is not clear.  This is a
problem because we'd very much like to see people contribute new
functionality and additional integrations.  They may be hesitant to do
so if they're unsure of the software license.  This patch addresses the
problem by making the license clear in the README.md and the LICENSE
file.

[ci skip] because no behavior is affected
