### PR TITLE
Search multiple boards and archive a card when a PR is closed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ group :development do
   gem 'pry-debugger'
   gem 'yard'
   gem 'redcarpet'
+  gem 'terminal-notifier'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,7 +31,7 @@ GEM
     debugger-linecache (1.1.2)
       debugger-ruby_core_source (>= 1.1.1)
     debugger-ruby_core_source (1.1.7)
-    delayed_job (3.0.4)
+    delayed_job (3.0.5)
       activesupport (~> 3.0)
     delayed_job_active_record (0.3.3)
       activerecord (>= 2.1.0, < 4)
@@ -86,7 +86,7 @@ GEM
     pry-debugger (0.2.1)
       debugger (~> 1.2.0)
       pry (~> 0.9.10)
-    rack (1.5.0)
+    rack (1.5.1)
     rack-protection (1.3.2)
       rack
     rack-test (0.6.2)
@@ -108,7 +108,7 @@ GEM
     rspec-expectations (2.12.1)
       diff-lcs (~> 1.1.3)
     rspec-mocks (2.12.2)
-    ruby-trello (0.5.0)
+    ruby-trello (0.5.1)
       activemodel
       addressable (~> 2.3)
       json
@@ -128,6 +128,7 @@ GEM
     slop (3.4.3)
     spoon (0.0.1)
     sqlite3 (1.3.7)
+    terminal-notifier (1.4.2)
     thin (1.5.0)
       daemons (>= 1.0.9)
       eventmachine (>= 0.12.6)
@@ -138,7 +139,7 @@ GEM
     watchr (0.7)
     wirb (1.0.1)
       paint
-    workless (1.1.1)
+    workless (1.1.2)
       delayed_job (>= 2.0.7)
       heroku-api
       rails
@@ -165,6 +166,7 @@ DEPENDENCIES
   sinatra
   sinatra-activerecord
   sqlite3
+  terminal-notifier
   thin
   watchr
   wirb

--- a/README.md
+++ b/README.md
@@ -324,6 +324,77 @@ To run the specs:
 
     $ bundle exec rake spec RACK_ENV=test
 
+Interactive Exploration
+====
+
+This code base is designed to be relatively straight forward to work with
+interactively using tools like `irb` and `pry`.  Here's how I quickly rig up
+instances of the jobs that are performed by this web app.  First, make sure you
+have an example of the JSON data stored in the fixtures directory.  For this
+example I'm going to use `spec/unit/fixtures/example_pull_request_closed.json`.
+
+Next, add something like the following two methods to `~/.irbrc`.  The goal is
+to quickly get a reference to an instance of the job that will be performed.
+
+```ruby
+##
+# jjm_load_path sets up the load path to include both the spec/ and lib/
+# directories.  This method makes the assumption that the present working
+# directory is the base directory of the project
+def jjm_load_path
+  spec = File.expand_path("spec")
+  $LOAD_PATH.delete spec
+  $LOAD_PATH.unshift spec
+  path = File.expand_path("lib")
+  $LOAD_PATH.delete path
+  $LOAD_PATH.unshift path
+  $LOAD_PATH[0..1]
+end
+
+##
+# jjm_prjob creates an instance of TrelloPullRequestJob suitable for
+# interactive testing.
+def jjm_prjob(fixture = "example_pull_request_closed.json")
+  jjm_load_path
+  require 'puppet_labs/pull_request_controller'
+  require 'spec_helper'
+  payload = read_fixture(fixture)
+  pull_request = PuppetLabs::PullRequest.new(:json => payload)
+  job = PuppetLabs::TrelloPullRequestJob.new
+  job.pull_request = pull_request
+  job
+end
+```
+
+Next, make sure your environment variables are configured and exported.  In
+order to interact with Trello, you'll need the following environment variables.
+If you already have a copy of this app running in Heroku it's super easy to get
+these variables set using `heroku config --shell | grep TRELLO | xargs -n1 echo
+export > trello_env.sh`, then simply `eval "$(trello_env.sh)"`.
+
+    TRELLO_APP_KEY
+    TRELLO_SECRET
+    TRELLO_TARGET_LIST_ID
+    TRELLO_USER_TOKEN
+
+Finally, make sure you're current working directory is in the root of the
+application repository and you should be ready to go.
+
+    $ bundle exec irb
+    Welcome to IRB. You are using ruby 1.9.3p327 (2012-11-10) [x86_64-darwin12.2.0]. Have fun ;)
+    >> job = jjm_prjob; nil #=> nil
+    >> job.perform #=> true
+    Processing: (PR puppet-webhooks/2) Test Pull Request 1
+    Done Processing: (PR puppet-webhooks/2) Test Pull Request 1
+    >>
+
+And you should see the results right on the board.
+
+![Trello Activity](https://dl.dropbox.com/u/469429/pics/trello_activity.png)
+
+Stick a `require 'pry'; binding.pry` statement inside of the `perform` method
+and you can dive right into the method itself.
+
 Maintainer
 ----
 

--- a/lib/puppet_labs/base_trello_job.rb
+++ b/lib/puppet_labs/base_trello_job.rb
@@ -70,7 +70,9 @@ class BaseTrelloJob
   def perform
     name = card_title
     display "Processing: #{name}"
-    unless card = find_card(name)
+    if card = find_card(name)
+      display "Card #{name} id=#{card.short_id} already exists at url=#{card.url}"
+    else
       create_card
     end
     display "Done Processing: #{name}"

--- a/lib/puppet_labs/base_trello_job.rb
+++ b/lib/puppet_labs/base_trello_job.rb
@@ -82,14 +82,51 @@ class BaseTrelloJob
     queue_job(self, options)
   end
 
+
+  ##
+  # Methods we discovered:
+  # card.delete - deletes the card
+  # card.add_comment("Hello"); - adds a comment.
+  # card.closed = true; card.save; - Archive a card.
+  # card.closed = false; card.save; - Un-archives a card.
+  # card.move_to_list(card.board.lists.first); - moves the card to the first
+  #   list on the board
+
   ##
   # find_card takes a title and locates the card using the Trello API.  If no
   # card exists on the target lists, then nil is returned.
+  #
+  # This method will extract the repository name and pull request number from
+  # the name and use the substring as the identifier.  For example, `"(PR
+  # puppet-webhooks/18) Add Apache 2.0 License"` will have an identifier of
+  # `"(PR puppet-webhooks/18)"`.  This behavior is meant to accomidate renames
+  # of the pull request title.
+  #
+  # If the environment variable TRELLO_BOARDS is set, then the value will be
+  # parsed as a comma separated list of Trello board identifiers.  All cards on
+  # each board will be searched in addition to the board containing the
+  # {list_id}.
+  #
+  # @return [Trello::Card] or {nil} if no card found.
   def find_card(name)
     api = trello_api
+    regexp = %r{\(.*/\d+\)}
+    if md = name.match(regexp)
+      identifier = md[0]
+    else
+      identifier = name
+    end
     all_cards = api.all_cards_on_board_of(list_id)
-    if card = all_cards.find { |card| card.name == name }
-      card
+    if card = all_cards.find { |card| card.name.include? identifier }
+      return card
+    end
+    if env['TRELLO_BOARDS']
+      env['TRELLO_BOARDS'].split(',').each do |board_id|
+        cards = api.all_cards_on_board(board_id)
+        if card = cards.find { |card| card.name.include? identifier }
+          return card
+        end
+      end
     end
   end
 

--- a/lib/puppet_labs/pull_request.rb
+++ b/lib/puppet_labs/pull_request.rb
@@ -9,7 +9,8 @@ class PullRequest
     :title,
     :html_url,
     :body,
-    :action
+    :action,
+    :message
 
   def self.from_json(json)
     new(:json => json)
@@ -23,6 +24,7 @@ class PullRequest
 
   def load_json(json)
     data = JSON.load(json)
+    @message = data
     @number = data['pull_request']['number']
     @title = data['pull_request']['title']
     @html_url = data['pull_request']['html_url']

--- a/lib/puppet_labs/trello_api.rb
+++ b/lib/puppet_labs/trello_api.rb
@@ -73,6 +73,14 @@ class TrelloAPI
     @cards[board.id]
   end
 
+  def all_cards_on_board(board_id)
+    board = ::Trello::Board.find(board_id)
+    if not @cards[board.id]
+      @cards[board.id] = board.cards
+    end
+    @cards[board.id]
+  end
+
   def list(list_id)
     if not @lists[list_id]
       @lists[list_id] = ::Trello::List.find(list_id)

--- a/lib/puppet_labs/trello_pull_request_job.rb
+++ b/lib/puppet_labs/trello_pull_request_job.rb
@@ -32,7 +32,18 @@ end
 
 class TrelloPullRequestClosedJob < TrelloPullRequestJob
   def perform
-    display "FIXME cannot perform any actions when a pull request is closed"
+    name = card_title
+    display "Processing: #{name}"
+    if card = find_card(name)
+      display "Found card #{name} id=#{card.short_id}"
+      # TODO Obtain the last comment on the pull request and act on it.
+      card.add_comment "Automatically archiving card, the pull request is closed."
+      card.closed = true
+      card.save
+    else
+      display "No card named #{name} found."
+    end
+    true
   end
 end
 

--- a/spec/unit/puppet_labs/issue_job_spec.rb
+++ b/spec/unit/puppet_labs/issue_job_spec.rb
@@ -123,6 +123,8 @@ describe PuppetLabs::TrelloIssueJob do
       before :each do
         fake_card = double(Trello::Card)
         fake_card.stub(:name).and_return(expected_card_title)
+        fake_card.stub(:short_id).and_return('1234')
+        fake_card.stub(:url).and_return('http://trello.com/foo/bar')
         subject.stub(:find_card).and_return(fake_card)
       end
       it 'does not create the card' do

--- a/spec/unit/puppet_labs/issue_job_spec.rb
+++ b/spec/unit/puppet_labs/issue_job_spec.rb
@@ -71,6 +71,11 @@ describe PuppetLabs::TrelloIssueJob do
       fake_api.should_receive(:all_cards_on_board_of).and_return([ fake_card ])
       subject.find_card(subject.card_title).should be fake_card
     end
+    it 'deals with renames by identifying the card using the parens' do
+      fake_api.should_receive(:all_cards_on_board_of).and_return([ fake_card ])
+      id = subject.card_title.match /\(.*?\/\d+\)/
+      subject.find_card("#{id} Renamed card title").should be fake_card
+    end
   end
 
   describe '#save_settings' do

--- a/spec/unit/puppet_labs/trello_pull_request_job_spec.rb
+++ b/spec/unit/puppet_labs/trello_pull_request_job_spec.rb
@@ -124,6 +124,8 @@ describe PuppetLabs::TrelloPullRequestJob do
       before :each do
         fake_card = double(Trello::Card)
         fake_card.stub(:name).and_return(expected_card_title)
+        fake_card.stub(:short_id).and_return('1234')
+        fake_card.stub(:url).and_return('http://trello.com/foo/bar')
         subject.stub(:find_card).and_return(fake_card)
       end
       it 'does not create the card' do

--- a/spec/unit/puppet_labs/trello_pull_request_job_spec.rb
+++ b/spec/unit/puppet_labs/trello_pull_request_job_spec.rb
@@ -72,6 +72,11 @@ describe PuppetLabs::TrelloPullRequestJob do
       fake_api.should_receive(:all_cards_on_board_of).and_return([ fake_card ])
       subject.find_card(subject.card_title).should be fake_card
     end
+    it 'deals with renames by identifying the card using the parens' do
+      fake_api.should_receive(:all_cards_on_board_of).and_return([ fake_card ])
+      id = subject.card_title.match /\(.*?\/\d+\)/
+      subject.find_card("#{id} Renamed card title").should be fake_card
+    end
   end
 
   describe '#save_settings' do


### PR DESCRIPTION
Without this patch the app takes no action when a pull request is
closed.  This is a problem because we often need to manually manage the
card on Trello.

This patch addresses the problem by searching for the card on the
primary board containing the list ID.  If the card is not found, the app
additionally searches for cards located on the boards identified by the
TRELLO_BOARDS environment variable which is expected to contain a comma
separated list of board identifiers.

This patch does not make any effort to figure out why the pull request
was closed.  It simply finds the card associated with the pull request,
adds a comment, and archives the card.

Finally, the behavior of the find_card method is changed by this patch.
An identifier located inside the parentheses and matching the regular
expression /(.*/\d+)/ will be extracted from the name passed to
find_card.  This substring will then be compared against all the card
titles on the multiple boards.
