### PR TITLE
Add a due date to cards created

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'json'
 gem 'sinatra-activerecord'
 gem 'delayed_job_active_record'
 gem 'workless', '~> 1.1.1'
+gem 'business_time'
 
 group :development do
   gem 'watchr'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,6 +20,9 @@ GEM
     awesome_print (1.0.2)
     boson (1.2.4)
     builder (3.0.4)
+    business_time (0.6.1)
+      activesupport (>= 3.1.0)
+      tzinfo (~> 0.3.31)
     clipboard (1.0.1)
     coderay (1.0.8)
     columnize (0.3.6)
@@ -73,7 +76,7 @@ GEM
     method_locator (0.0.4)
     method_source (0.8.1)
     methodfinder (1.2.5)
-    mime-types (1.19)
+    mime-types (1.20.1)
     multi_json (1.5.0)
     oauth (0.4.7)
     ori (0.1.0)
@@ -144,13 +147,14 @@ GEM
       heroku-api
       rails
       rush
-    yard (0.8.3)
+    yard (0.8.4)
     zucker (12.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  business_time
   delayed_job_active_record
   hub
   irbtools

--- a/lib/puppet_labs/base_trello_job.rb
+++ b/lib/puppet_labs/base_trello_job.rb
@@ -1,6 +1,7 @@
 require 'puppet_labs/trello_api'
 require 'puppet_labs/sinatra_dj'
 require 'logger'
+require 'business_time'
 
 module PuppetLabs
 ##
@@ -73,7 +74,20 @@ class BaseTrelloJob
     if card = find_card(name)
       display "Card #{name} id=#{card.short_id} already exists at url=#{card.url}"
     else
-      create_card
+      if card = create_card
+        if env['TRELLO_SET_TARGET_RESPONSE_TIME'] == 'true'
+          due_date = target_response_time
+          card.due = due_date
+          display "Set due date of #{name} to #{card.due} url=#{card.url}"
+        else
+          display "TRELLO_SET_TARGET_RESPONSE_TIME is not 'true' "+
+            "not setting card due date for #{name}"
+        end
+        display "Created card #{name} url=#{card.url}"
+        card.save
+      else
+        display "Did not create card #{name}"
+      end
     end
     display "Done Processing: #{name}"
   end
@@ -133,14 +147,31 @@ class BaseTrelloJob
 
   ##
   # create_card creates a card on the target Trello board
-  def create_card
+  def create_card(options = {})
     trello = trello_api
     card_options = {
       :name => card_title,
       :list => list_id,
       :description => card_body,
-    }
+    }.merge(options)
     trello.create_card(card_options)
+  end
+
+  ##
+  # target_response_time will return the target due date for a card.  This due
+  # date is meant be used as the time that tracks the target response time of
+  # the pull request.  This defaults to 5 business hours after the start of the
+  # next business day (2 PM).
+  #
+  # @return [Time] the due date of the card.
+  def target_response_time
+    now = Time.now
+    if Time.before_business_hours?(now)
+      next_business_day = now.midnight
+    else
+      next_business_day = 1.business_day.after(now).midnight
+    end
+    due_date = 5.business_hour.after(next_business_day)
   end
 
   def trello_api

--- a/lib/puppet_labs/base_trello_job.rb
+++ b/lib/puppet_labs/base_trello_job.rb
@@ -128,6 +128,7 @@ class BaseTrelloJob
         end
       end
     end
+    nil
   end
 
   ##

--- a/lib/puppet_labs/pull_request.rb
+++ b/lib/puppet_labs/pull_request.rb
@@ -32,5 +32,9 @@ class PullRequest
     @repo_name = data['repository']['name']
     @action = data['action']
   end
+
+  def created_at
+    message['pull_request']['created_at']
+  end
 end
 end

--- a/lib/puppet_labs/trello_api.rb
+++ b/lib/puppet_labs/trello_api.rb
@@ -43,6 +43,10 @@ class TrelloAPI
     ::Trello::Board.find(board_id).lists
   end
 
+  ##
+  # create card creates a new card on the target list id.
+  #
+  # @return [Trello::Card] representing the new card
   def create_card(properties)
     card = ::Trello::Card.create(:name => properties[:name],
                                  :list_id => properties[:list],
@@ -50,6 +54,7 @@ class TrelloAPI
     if properties[:color]
       card.add_label(properties[:color])
     end
+    card
   end
 
   def archive_card(card)

--- a/lib/puppet_labs/trello_pull_request_job.rb
+++ b/lib/puppet_labs/trello_pull_request_job.rb
@@ -50,6 +50,8 @@ end
 class TrelloPullRequestReopenedJob < TrelloPullRequestJob
   def perform
     display "FIXME cannot perform any actions when a pull request is reopened"
+    # Move the card to the target list
+    # Set a new due date for the card
   end
 end
 end


### PR DESCRIPTION
Without this patch the cards created by this app have no due date
associated with them.  This is a problem because I'd like to make sure
all cards have actions by 2 PM the business day following when they were
created.

This patch addresses the problem by checking if
TRELLO_SET_TARGET_RESPONSE_TIME has the value "true" and if so, sets a
due date on the newly created card.

This card should automatically be created at
https://trello.com/board/puppet-webhooks/50fc6650e0a305d1410043ed
