### PR TITLE
Add a due date to cards created

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'json'
 gem 'sinatra-activerecord'
 gem 'delayed_job_active_record'
 gem 'workless', '~> 1.1.1'
+gem 'business_time'
 
 group :development do
   gem 'watchr'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,6 +20,9 @@ GEM
     awesome_print (1.0.2)
     boson (1.2.4)
     builder (3.0.4)
+    business_time (0.6.1)
+      activesupport (>= 3.1.0)
+      tzinfo (~> 0.3.31)
     clipboard (1.0.1)
     coderay (1.0.8)
     columnize (0.3.6)
@@ -73,7 +76,7 @@ GEM
     method_locator (0.0.4)
     method_source (0.8.1)
     methodfinder (1.2.5)
-    mime-types (1.19)
+    mime-types (1.20.1)
     multi_json (1.5.0)
     oauth (0.4.7)
     ori (0.1.0)
@@ -144,13 +147,14 @@ GEM
       heroku-api
       rails
       rush
-    yard (0.8.3)
+    yard (0.8.4)
     zucker (12.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  business_time
   delayed_job_active_record
   hub
   irbtools

--- a/README.md
+++ b/README.md
@@ -13,8 +13,12 @@ This project performs a job or jobs when a pull request event occurs on
  * [✓] Auto-scale the number of workers to zero when there are no jobs to perform.
  * [✓] Auto-scale the number of workers to one when there are jobs to perform.
  * [✓] Near real-time behavior, no polling intervals involved.
- * [ ] Archive a Trello Card when a Pull Request is closed.
- * [ ] Check multiple boards for the existence of a card.
+ * [✓] Near real-time behavior, no polling intervals involved.
+ * [✓] Archive a Trello Card when a Pull Request is closed.
+ * [✓] Check multiple boards for the existence of a card if `TRELLO_BOARDS`
+   contains a comma separated list of board ID's.
+ * [✓] Set the card due date to 2 PM next business day when a card is created
+   if `TRELLO_SET_TARGET_RESPONSE_TIME=true`.
  * [ ] Copy a comment to the card when a comment is added to the pull request.
 
 [web-service-hook]: https://github.com/github/github-services/blob/master/services/web.rb
@@ -73,6 +77,43 @@ Next, push the application to [Heroku][heroku] with `git push heroku HEAD:master
            http://fierce-meadow-9708.herokuapp.com deployed to Heroku
     To git@heroku.com:fierce-meadow-9708.git
      * [new branch]      HEAD -> master
+
+Configuration Options
+----
+
+The application is up and running at this point, but the following
+configuration options may be useful.  All of the configuration of this
+application is done using environment variables set through the `heroku
+config:add` action.
+
+Due Dates and Timezones
+----
+
+Add a due date for newly created cards if you have a target response time for
+pull requests you'd like to track.  At Puppet Labs we use this as a clear way
+to stay on top of incoming pull requests.  If this variable is `"true"` then
+the application will set the due date of a newly created cards to 2 PM of the
+next business day.  Please note this behavior depends on the timezone.
+
+    $ heroku config:set TRELLO_SET_TARGET_RESPONSE_TIME=true
+    $ heroku config:set TZ=America/Los_Angeles
+
+A list of timezone strings may be found at [List of tz database time
+zones](http://en.wikipedia.org/wiki/List_of_tz_database_time_zones)
+
+Multiple Boards
+----
+
+Often times a card will move from one board to another board if there are
+multiple teams working together.  If a card is not located on the board
+containing the target list for newly created cards, then the application will
+not find the already created card by default.  The app may be configured to
+search for a card on additional boards if the card is not found on the board
+containing the target list.  To do so, set the `TRELLO_BOARDS` variable to a
+comma separated list of board identifiers.  (Note, the board ID may be copied
+directly from the Trello URL)
+
+    $ heroku config:set TRELLO_BOARDS=4fd8ed1769c9e77f1e0d6882,50bd46a84c27cb74100035f5
 
 Database Migration
 ----

--- a/lib/puppet_labs/base_trello_job.rb
+++ b/lib/puppet_labs/base_trello_job.rb
@@ -163,6 +163,9 @@ class BaseTrelloJob
   # the pull request.  This defaults to 5 business hours after the start of the
   # next business day (2 PM).
   #
+  # This method depends on the time zone being set to the correct region for
+  # the business.  e.g. TZ=America/Los_Angeles
+  #
   # @return [Time] the due date of the card.
   def target_response_time
     now = Time.now

--- a/lib/puppet_labs/base_trello_job.rb
+++ b/lib/puppet_labs/base_trello_job.rb
@@ -1,6 +1,7 @@
 require 'puppet_labs/trello_api'
 require 'puppet_labs/sinatra_dj'
 require 'logger'
+require 'business_time'
 
 module PuppetLabs
 ##
@@ -73,7 +74,20 @@ class BaseTrelloJob
     if card = find_card(name)
       display "Card #{name} id=#{card.short_id} already exists at url=#{card.url}"
     else
-      create_card
+      if card = create_card
+        if env['TRELLO_SET_TARGET_RESPONSE_TIME'] == 'true'
+          due_date = target_response_time
+          card.due = due_date
+          display "Set due date of #{name} to #{card.due} url=#{card.url}"
+        else
+          display "TRELLO_SET_TARGET_RESPONSE_TIME is not 'true' "+
+            "not setting card due date for #{name}"
+        end
+        display "Created card #{name} url=#{card.url}"
+        card.save
+      else
+        display "Did not create card #{name}"
+      end
     end
     display "Done Processing: #{name}"
   end
@@ -133,14 +147,31 @@ class BaseTrelloJob
 
   ##
   # create_card creates a card on the target Trello board
-  def create_card
+  def create_card(options = {})
     trello = trello_api
     card_options = {
       :name => card_title,
       :list => list_id,
       :description => card_body,
-    }
+    }.merge(options)
     trello.create_card(card_options)
+  end
+
+  ##
+  # target_response_time will return the target due date for a card.  This due
+  # date is meant be used as the time that tracks the target response time of
+  # the pull request.  This defaults to 5 business hours after the start of the
+  # next business day (2 PM).
+  #
+  # @return [Time] the due date of the card.
+  def target_response_time
+    now = Time.now
+    if Time.before_business_hours?(now)
+      next_business_day = now.midnight
+    else
+      next_business_day = 1.business_day.after(now).midnight
+    end
+    due_date = 5.business_hour.after(next_business_day)
   end
 
   def trello_api

--- a/lib/puppet_labs/base_trello_job.rb
+++ b/lib/puppet_labs/base_trello_job.rb
@@ -128,6 +128,7 @@ class BaseTrelloJob
         end
       end
     end
+    nil
   end
 
   ##

--- a/lib/puppet_labs/pull_request.rb
+++ b/lib/puppet_labs/pull_request.rb
@@ -32,5 +32,9 @@ class PullRequest
     @repo_name = data['repository']['name']
     @action = data['action']
   end
+
+  def created_at
+    message['pull_request']['created_at']
+  end
 end
 end

--- a/lib/puppet_labs/trello_api.rb
+++ b/lib/puppet_labs/trello_api.rb
@@ -43,6 +43,10 @@ class TrelloAPI
     ::Trello::Board.find(board_id).lists
   end
 
+  ##
+  # create card creates a new card on the target list id.
+  #
+  # @return [Trello::Card] representing the new card
   def create_card(properties)
     card = ::Trello::Card.create(:name => properties[:name],
                                  :list_id => properties[:list],
@@ -50,6 +54,7 @@ class TrelloAPI
     if properties[:color]
       card.add_label(properties[:color])
     end
+    card
   end
 
   def archive_card(card)

--- a/lib/puppet_labs/trello_pull_request_job.rb
+++ b/lib/puppet_labs/trello_pull_request_job.rb
@@ -50,6 +50,8 @@ end
 class TrelloPullRequestReopenedJob < TrelloPullRequestJob
   def perform
     display "FIXME cannot perform any actions when a pull request is reopened"
+    # Move the card to the target list
+    # Set a new due date for the card
   end
 end
 end


### PR DESCRIPTION
Without this patch the cards created by this app have no due date
associated with them.  This is a problem because I'd like to make sure
all cards have actions by 2 PM the business day following when they were
created.

This patch addresses the problem by checking if
TRELLO_SET_TARGET_RESPONSE_TIME has the value "true" and if so, sets a
due date on the newly created card.
