### PR TITLE
WIP Add author information to card

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gem 'rake'
 # in the Gemfile. This populates the DATABASE_URL environment var.
 gem 'sinatra'
 gem 'ruby-trello'
+gem 'octokit' # github
 gem 'json'
 
 gem 'sinatra-activerecord'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,8 +46,13 @@ GEM
     fancy_irb (0.7.3)
       paint (>= 0.8.1)
       unicode-display_width (>= 0.1.1)
+    faraday (0.8.5)
+      multipart-post (~> 1.1)
+    faraday_middleware (0.9.0)
+      faraday (>= 0.7.4, < 0.9)
     fattr (2.2.1)
     g (1.7.2)
+    hashie (1.2.0)
     heroku-api (0.3.7)
       excon (~> 0.16.10)
     hirb (0.7.1)
@@ -78,7 +83,16 @@ GEM
     methodfinder (1.2.5)
     mime-types (1.20.1)
     multi_json (1.5.0)
+    multipart-post (1.1.5)
+    netrc (0.7.7)
     oauth (0.4.7)
+    octokit (1.22.0)
+      addressable (~> 2.2)
+      faraday (~> 0.8)
+      faraday_middleware (~> 0.9)
+      hashie (~> 1.2)
+      multi_json (~> 1.3)
+      netrc (~> 0.7.7)
     ori (0.1.0)
     paint (0.8.5)
     pg (0.14.1)
@@ -159,6 +173,7 @@ DEPENDENCIES
   hub
   irbtools
   json
+  octokit
   pg
   pry
   pry-debugger

--- a/lib/puppet_labs/github_api.rb
+++ b/lib/puppet_labs/github_api.rb
@@ -1,0 +1,23 @@
+require 'octokit'
+
+module PuppetLabs
+class GithubAPI
+  attr_reader :env
+
+  def initialize(options = {})
+    options[:env] ||= ENV.to_hash
+    @env = options[:env]
+    @accounts = {}
+  end
+
+  def github_api(options = {})
+    options[:login] ||= ENV['GITHUB_ACCOUNT']
+    options[:oauth_token] ||= ENV['GITHUB_TOKEN']
+    @github_api ||= Octokit::Client.new(options)
+  end
+
+  def account(login)
+    @accounts[login] ||= github_api.user(login)
+  end
+end
+end

--- a/lib/puppet_labs/github_mix.rb
+++ b/lib/puppet_labs/github_mix.rb
@@ -1,0 +1,25 @@
+require 'puppet_labs/github_api'
+
+module PuppetLabs
+module GithubMix
+  def github
+    @github ||= PuppetLabs::GithubAPI.new(:env => env)
+  end
+
+  def author_name
+    github.account(author)['name']
+  end
+
+  def author_email
+    github.account(author)['email']
+  end
+
+  def author_company
+    github.account(author)['company']
+  end
+
+  def author_html_url
+    github.account(author)['html_url']
+  end
+end
+end

--- a/lib/puppet_labs/pull_request.rb
+++ b/lib/puppet_labs/pull_request.rb
@@ -1,10 +1,13 @@
 require 'json'
+require 'puppet_labs/github_mix'
 
 # This class provides a model of a pull rquest.
 module PuppetLabs
 class PullRequest
+  include GithubMix
   # Pull request data
   attr_reader :number,
+    :env,
     :repo_name,
     :title,
     :html_url,
@@ -19,6 +22,11 @@ class PullRequest
   def initialize(options = {})
     if json = options[:json]
       load_json(json)
+    end
+    if env = options[:env]
+      @env = env
+    else
+      @env = ENV.to_hash
     end
   end
 
@@ -35,6 +43,14 @@ class PullRequest
 
   def created_at
     message['pull_request']['created_at']
+  end
+
+  def author
+    message['sender']['login']
+  end
+
+  def author_avatar_url
+    message['sender']['avatar_url']
   end
 end
 end

--- a/lib/puppet_labs/trello_issue_job.rb
+++ b/lib/puppet_labs/trello_issue_job.rb
@@ -19,8 +19,12 @@ class TrelloIssueJob < BaseTrelloJob
     ].join("\n")
   end
 
+  def card_identifier
+    "(GH-ISSUE #{issue.repo_name}/#{issue.number})"
+  end
+
   def card_title
-    "(GH-ISSUE #{issue.repo_name}/#{issue.number}) #{issue.title}"
+    "#{card_identifier} #{issue.title}"
   end
 
   def queue_name

--- a/lib/puppet_labs/trello_pull_request_job.rb
+++ b/lib/puppet_labs/trello_pull_request_job.rb
@@ -13,16 +13,31 @@ class TrelloPullRequestJob < BaseTrelloJob
 
   def card_body
     pr = pull_request
-    str = [ "Links: [Pull Request #{pr.number} Discussion](#{pr.html_url}) and",
-            "[File Diff](#{pr.html_url}/files)",
+    str = [ 'Contributor Information',
+            '----',
             '',
+            "![#{pr.author_name}](#{pr.author_avatar_url})",
+            '',
+            " * Author: **#{pr.author_name}** <#{pr.author_email}>",
+            " * Company: #{pr.author_company}",
+            " * Github ID: [#{pr.author}](#{pr.author_html_url})",
+            " * [Pull Request #{pr.number} Discussion](#{pr.html_url})",
+            " * [File Diff](#{pr.html_url}/files)",
+            '',
+            'Pull Request',
+            '====',
             pr.body,
     ].join("\n")
   end
 
+  def card_identifier
+    pr = pull_request
+    "(PR #{pr.repo_name}/#{pr.number})"
+  end
+
   def card_title
     pr = pull_request
-    "(PR #{pr.repo_name}/#{pr.number}) #{pr.title}"
+    "#{card_identifier} #{pr.title} [#{pr.author_name}]"
   end
 
   def queue_name


### PR DESCRIPTION
Without this patch, while looking at the Trello board it's difficult to
see who opened a pull request.  This is a problem because I often need
to find a card that a particular user is talking about.

This patch addresses the problem by adding an avatar image of the
contributor, their full name, their company, and their email to the
description of the card.  In addition, their full name is included in
the card title.

As part of this change the job needs to communicate with Github to
obtain the full data about the github login who sent the pull request.

Here's what the card looks like:

![Trello Card](http://goo.gl/sNMa3)
