### PR TITLE
Put the Github account name in the card title if the full name is not available

### DIFF
--- a/lib/puppet_labs/github_mix.rb
+++ b/lib/puppet_labs/github_mix.rb
@@ -7,7 +7,12 @@ module GithubMix
   end
 
   def author_name
-    github.account(author)['name']
+    account = author
+    if name = github.account(account)['name'] and not name.empty?
+      name
+    else
+      account
+    end
   end
 
   def author_email

--- a/spec/unit/puppet_labs/github_mix_spec.rb
+++ b/spec/unit/puppet_labs/github_mix_spec.rb
@@ -39,4 +39,27 @@ describe "PuppetLabs::GithubMix mixin" do
       subject.author_html_url.should == 'https://github.com/jeffmccune'
     end
   end
+
+  context 'incomplete account information' do
+    let(:account) do
+      {
+        'html_url' => 'https://github.com/jeffmccune',
+      }
+    end
+    let(:github) do
+      github = double('GithubAPI', :account => account)
+    end
+    before :each do
+      subject.stub(:github).and_return(github)
+    end
+
+    it 'uses the account name if the user name is nil' do
+      subject.author_name.should == 'jeffmccune'
+    end
+    it 'uses the account name if the user name is empty' do
+      github = double('GithubAPI', :account => account.merge('name' => ''))
+      subject.stub(:github).and_return(github)
+      subject.author_name.should == 'jeffmccune'
+    end
+  end
 end

--- a/spec/unit/puppet_labs/github_mix_spec.rb
+++ b/spec/unit/puppet_labs/github_mix_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+require 'puppet_labs/github_mix'
+
+describe "PuppetLabs::GithubMix mixin" do
+  class FakeJob
+    include PuppetLabs::GithubMix
+    def author
+      @author ||= 'jeffmccune'
+    end
+  end
+  subject { FakeJob.new }
+
+  context 'complete account information' do
+    let(:account) do
+      {
+        'name' => 'Jeff McCune',
+        'email' => 'jeff@puppetlabs.com',
+        'company' => 'Puppet Labs',
+        'html_url' => 'https://github.com/jeffmccune',
+      }
+    end
+    let(:github) do
+      github = double('GithubAPI', :account => account)
+    end
+    before :each do
+      subject.stub(:github).and_return(github)
+    end
+
+    it 'uses the github API to retrieve the author name' do
+      subject.author_name.should == 'Jeff McCune'
+    end
+    it 'uses the github API to retrieve the author email' do
+      subject.author_email.should == 'jeff@puppetlabs.com'
+    end
+    it 'uses the github API to retrieve the author company' do
+      subject.author_company.should == 'Puppet Labs'
+    end
+    it 'uses the github API to retrieve the author account URL' do
+      subject.author_html_url.should == 'https://github.com/jeffmccune'
+    end
+  end
+end


### PR DESCRIPTION
Without this patch the author_name method of the GithubMix module will
return nil if the full name of the account is not available.  This is a
problem because the full name is often not available, for example:
https://github.com/brunoleon does not have an email address, full name,
or company, and the card titles look weird, like:

```
(PR hiera/123) Interpolate hash keys like already done for strings. []
```

This patch addresses the problem by returning the account name if the
full name is not available, so the card title looks better.  For
example:

```
(PR hiera/123) Interpolate hash keys like already done for strings. [brunoleon]
```
