### PR TITLE
Only archive cards if ARCHIVE_CARD=true or yes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ This project performs a job or jobs when a pull request event occurs on
  * [✓] Auto-scale the number of workers to one when there are jobs to perform.
  * [✓] Near real-time behavior, no polling intervals involved.
  * [✓] Near real-time behavior, no polling intervals involved.
- * [✓] Archive a Trello Card when a Pull Request is closed.
+ * [✓] Archive a Trello Card when a Pull Request is closed if `ARCHIVE_CARD` is
+   `true` or `yes`.
  * [✓] Check multiple boards for the existence of a card if `TRELLO_BOARDS`
    contains a comma separated list of board ID's.
  * [✓] Set the card due date to 2 PM next business day when a card is created

--- a/lib/puppet_labs/base_trello_job.rb
+++ b/lib/puppet_labs/base_trello_job.rb
@@ -20,6 +20,20 @@ class BaseTrelloJob
   attr_writer :env
 
   ##
+  # archive_card? will return true if ARCHIVE_CARD=true in the environment.
+  # This provides a way for Trello jobs to figure out if they shoudl archive
+  # closed cards or not.
+  #
+  # @api public
+  def archive_card?
+    if ac = @archive_card and ac.match(/^(true|yes)$/i)
+      true
+    else
+      false
+    end
+  end
+
+  ##
   # card_body must be overrided by subclasses.
   #
   # @api public
@@ -63,6 +77,7 @@ class BaseTrelloJob
     @key = env['TRELLO_APP_KEY']
     @secret = env['TRELLO_SECRET']
     @token = env['TRELLO_USER_TOKEN']
+    @archive_card = env['ARCHIVE_CARD']
   end
 
   ##

--- a/lib/puppet_labs/trello_pull_request_job.rb
+++ b/lib/puppet_labs/trello_pull_request_job.rb
@@ -52,8 +52,12 @@ class TrelloPullRequestClosedJob < TrelloPullRequestJob
     if card = find_card(name)
       display "Found card #{name} id=#{card.short_id}"
       # TODO Obtain the last comment on the pull request and act on it.
-      card.add_comment "Automatically archiving card, the pull request is closed."
-      card.closed = true
+      if archive_card?
+        card.add_comment "Automatically archiving card, the pull request is closed."
+        card.closed = true
+      else
+        card.add_comment "This pull request is closed."
+      end
       card.save
     else
       display "No card named #{name} found."

--- a/spec/unit/puppet_labs/base_trello_job_spec.rb
+++ b/spec/unit/puppet_labs/base_trello_job_spec.rb
@@ -14,6 +14,7 @@ describe PuppetLabs::BaseTrelloJob do
         'TRELLO_SECRET' => 'sekret',
         'TRELLO_USER_TOKEN' => 'token',
         'TRELLO_TARGET_LIST_ID' => 'list_id',
+        'ARCHIVE_CARD' => 'true',
       }
     end
 
@@ -36,6 +37,57 @@ describe PuppetLabs::BaseTrelloJob do
     it "saves TRELLO_TARGET_LIST_ID as list_id" do
       subject.save_settings
       subject.list_id.should == 'list_id'
+    end
+    it "saves ARCHIVE_CARD to enable #archive_card?" do
+      subject.save_settings
+      subject.archive_card?.should be_true
+    end
+  end
+
+  describe '#archive_card?' do
+    it 'is false by default' do
+      subject.save_settings
+      subject.archive_card?.should be_false
+    end
+    it 'is false if ARCHIVE_CARD is empty' do
+      subject.env = { 'ARCHIVE_CARD' => '' }
+      subject.save_settings
+      subject.archive_card?.should be_false
+    end
+    it 'is false if ARCHIVE_CARD is garbage' do
+      subject.env = { 'ARCHIVE_CARD' => 'asdfasdf' }
+      subject.save_settings
+      subject.archive_card?.should be_false
+    end
+    it 'is true if ARCHIVE_CARD is TRUE' do
+      subject.env = { 'ARCHIVE_CARD' => 'TRUE' }
+      subject.save_settings
+      subject.archive_card?.should be_true
+    end
+    it 'is true if ARCHIVE_CARD is true' do
+      subject.env = { 'ARCHIVE_CARD' => 'true' }
+      subject.save_settings
+      subject.archive_card?.should be_true
+    end
+    it 'is true if ARCHIVE_CARD is YES' do
+      subject.env = { 'ARCHIVE_CARD' => 'YES' }
+      subject.save_settings
+      subject.archive_card?.should be_true
+    end
+    it 'is true if ARCHIVE_CARD is yes' do
+      subject.env = { 'ARCHIVE_CARD' => 'yes' }
+      subject.save_settings
+      subject.archive_card?.should be_true
+    end
+    it 'is false if ARCHIVE_CARD is YESnoYES' do
+      subject.env = { 'ARCHIVE_CARD' => 'YESnoYES' }
+      subject.save_settings
+      subject.archive_card?.should be_false
+    end
+    it 'is false if ARCHIVE_CARD is TRUEnoTRUE' do
+      subject.env = { 'ARCHIVE_CARD' => 'TRUEnoTRUE' }
+      subject.save_settings
+      subject.archive_card?.should be_false
     end
   end
 end

--- a/spec/unit/puppet_labs/base_trello_job_spec.rb
+++ b/spec/unit/puppet_labs/base_trello_job_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+require 'puppet_labs/trello_pull_request_job'
+
+describe PuppetLabs::BaseTrelloJob do
+  subject do
+    job = PuppetLabs::BaseTrelloJob.new
+    job
+  end
+
+  describe '#save_settings' do
+    let(:env) do
+      {
+        'TRELLO_APP_KEY' => 'key',
+        'TRELLO_SECRET' => 'sekret',
+        'TRELLO_USER_TOKEN' => 'token',
+        'TRELLO_TARGET_LIST_ID' => 'list_id',
+      }
+    end
+
+    before :each do
+      subject.env = env
+    end
+
+    it "saves TRELLO_APP_KEY as key" do
+      subject.save_settings
+      subject.key.should == 'key'
+    end
+    it "saves TRELLO_SECRET as secret" do
+      subject.save_settings
+      subject.secret.should == 'sekret'
+    end
+    it "saves TRELLO_USER_TOKEN as token" do
+      subject.save_settings
+      subject.token.should == 'token'
+    end
+    it "saves TRELLO_TARGET_LIST_ID as list_id" do
+      subject.save_settings
+      subject.list_id.should == 'list_id'
+    end
+  end
+end

--- a/spec/unit/puppet_labs/trello_pull_request_job_spec.rb
+++ b/spec/unit/puppet_labs/trello_pull_request_job_spec.rb
@@ -105,34 +105,6 @@ describe PuppetLabs::TrelloPullRequestJob do
     end
   end
 
-  describe '#save_settings' do
-    let(:env) do
-      {
-        'TRELLO_APP_KEY' => 'key',
-        'TRELLO_SECRET' => 'sekret',
-        'TRELLO_USER_TOKEN' => 'token',
-        'TRELLO_TARGET_LIST_ID' => 'list_id',
-      }
-    end
-
-    it "saves TRELLO_APP_KEY as key" do
-      subject.save_settings
-      subject.key == env['TRELLO_APP_KEY']
-    end
-    it "saves TRELLO_SECRET as secret" do
-      subject.save_settings
-      subject.secret == env['TRELLO_SECRET']
-    end
-    it "saves TRELLO_USER_TOKEN as token" do
-      subject.save_settings
-      subject.token == env['TRELLO_USER_TOKEN']
-    end
-    it "saves TRELLO_TARGET_LIST_ID as list_id" do
-      subject.save_settings
-      subject.list_id == env['TRELLO_TARGET_LIST_ID']
-    end
-  end
-
   context 'performing the task' do
     before :each do
       subject.stub(:find_card)

--- a/spec/unit/puppet_labs/trello_pull_request_job_spec.rb
+++ b/spec/unit/puppet_labs/trello_pull_request_job_spec.rb
@@ -138,3 +138,79 @@ describe PuppetLabs::TrelloPullRequestJob do
     end
   end
 end
+
+describe PuppetLabs::TrelloPullRequestClosedJob do
+  class FakeError < StandardError; end
+
+  let(:payload) { read_fixture("example_pull_request_closed.json") }
+  let (:pr) { PuppetLabs::PullRequest.new(:json => payload) }
+
+  let :fake_api do
+    fake_api = double(PuppetLabs::TrelloAPI)
+    fake_api.stub(:create_card)
+    fake_api.stub(:all_cards_on_board_of).and_return([])
+    fake_api
+  end
+
+  let :expected_card_identifier do
+    "(PR #{pr.repo_name}/#{pr.number})"
+  end
+
+  let :expected_card_title do
+    "#{expected_card_identifier} #{pr.title}"
+  end
+
+  subject do
+    job = PuppetLabs::TrelloPullRequestClosedJob.new
+    job.pull_request = PuppetLabs::PullRequest.new(:json => payload)
+    job
+  end
+
+  before :each do
+    subject.stub(:display_card)
+    subject.stub(:trello_api).and_return(fake_api)
+    PuppetLabs::GithubAPI.any_instance.stub(:account).with('jeffmccune').and_return(github_account)
+  end
+
+  def github_account
+    @github_account ||= {
+      'name' => 'Jeff McCune',
+      'email' => 'jeff@puppetlabs.com',
+      'company' => 'Puppet Labs',
+      'html_url' => 'https://github.com/jeffmccune',
+    }
+  end
+
+  context 'performing the task' do
+    let :fake_card do
+      card = double(Trello::Card)
+      card.stub(:name).and_return(expected_card_title)
+      card.stub(:short_id).and_return('1234')
+      card.stub(:url).and_return('http://trello.com/foo/bar')
+      card.stub(:add_comment)
+      card.stub(:closed=)
+      card.stub(:save)
+      card
+    end
+
+    it 'adds a comment to the card' do
+      fake_card.should_receive(:add_comment).with(/closed/i)
+      subject.stub(:find_card).and_return(fake_card)
+      subject.perform
+    end
+
+    it 'does not archive the card if #archive_card? is false' do
+      fake_card.should_not_receive(:closed=)
+      subject.stub(:find_card).and_return(fake_card)
+      subject.stub(:archive_card?).and_return(false)
+      subject.perform
+    end
+    it 'archives the card if #archive_card? is true' do
+      fake_card.should_receive(:closed=).with(true)
+      subject.stub(:find_card).and_return(fake_card)
+      subject.stub(:archive_card?).and_return(true)
+      subject.perform
+    end
+
+  end
+end


### PR DESCRIPTION
This patch finishes the work wiring up delayed jobs to the original user-configured environment.  With this patch applied the TrelloPullRequestClosedJob class will only archive a card if the application environment was configured with ARCHIVE_CARD=true or ARCHIVE_CARD=yes at the time the job was originally created.

The values are case insensitive.
