### PR TITLE
Add CLA status check if CLA_STATUS_CHECK=true

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,8 @@ gem 'ruby-trello'
 gem 'octokit' # github
 gem 'json'
 gem 'liquid'
+gem 'httparty'
+gem 'chronic_duration'
 
 gem 'sinatra-activerecord'
 gem 'delayed_job_active_record'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,6 +28,8 @@ GEM
     business_time (0.6.1)
       activesupport (>= 3.1.0)
       tzinfo (~> 0.3.31)
+    chronic_duration (0.10.2)
+      numerizer (~> 0.1.1)
     clipboard (1.0.1)
     coderay (1.0.9)
     columnize (0.3.6)
@@ -60,6 +62,9 @@ GEM
     heroku-api (0.3.8)
       excon (~> 0.16.10)
     hirb (0.7.1)
+    httparty (0.11.0)
+      multi_json (~> 1.0)
+      multi_xml (>= 0.5.2)
     hub (1.10.5)
     i18n (0.6.4)
     interactive_editor (0.0.10)
@@ -88,8 +93,10 @@ GEM
     methodfinder (1.2.5)
     mime-types (1.21)
     multi_json (1.6.1)
+    multi_xml (0.5.4)
     multipart-post (1.2.0)
     netrc (0.7.7)
+    numerizer (0.1.1)
     oauth (0.4.7)
     octokit (1.23.0)
       addressable (~> 2.2)
@@ -174,8 +181,10 @@ PLATFORMS
 
 DEPENDENCIES
   business_time
+  chronic_duration
   delayed_job_active_record
   gepetto_hooks!
+  httparty
   hub
   irbtools
   json

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ This project performs a job or jobs when a pull request event occurs on
  * [✓] Summarize finished cards on a periodic basis using `$ bundle exec rake
    jobs:summary`
  * [✓] Copy a comment to the card when a comment is added to the pull request.
+ * [✓] Check the CLA status when `CLA_STATUS_CHECK=true`.
 
 [web-service-hook]: https://github.com/github/github-services/blob/master/services/web.rb
 
@@ -421,6 +422,18 @@ The template used to produce the summary may be configured using the
 
 The default template is located at
 [trello_template.md.liquid](https://github.com/puppetlabs/puppet-webhooks/blob/templates/templates/trello_template.md.liquid).
+
+CLA Status Check
+====
+
+The CLA status API at `https://cla.puppetlabs.com/api/v1/` may be used to check
+the Puppet Labs CLA status using the Github user id.  To enable this set the
+following three configuration variables.
+
+    heroku config:set \
+      CLA_STATUS_CHECK=true \
+      CLA_API_USERNAME=puppetlabs \
+      CLA_API_PASSWORD='changeme'
 
 Examples
 ====

--- a/lib/puppet_labs/cla_api.rb
+++ b/lib/puppet_labs/cla_api.rb
@@ -1,0 +1,47 @@
+require 'httparty'
+
+module PuppetLabs
+class ClaAPI
+  include HTTParty
+  class ApiError < StandardError; end
+  base_uri 'https://cla.puppetlabs.com/api/v1'
+
+  attr_reader :env
+
+  def initialize(options = {})
+    options[:env] ||= ENV.to_hash
+    @env = options[:env]
+    @auth = {}
+    if username = options[:env]['CLA_API_USERNAME']
+      @auth[:username] = username
+    end
+    if password = options[:env]['CLA_API_PASSWORD']
+      @auth[:password] = password
+    end
+  end
+
+  def enabled?
+    env['CLA_STATUS_CHECK'] == 'true'
+  end
+
+  ##
+  # signed_cla_at returns the time a contributor signed the CLA.
+  #
+  # @param [String] user The user id of the contributor.
+  #
+  # @api private
+  #
+  # @return [Time, nil]
+  def signed_cla_at(user, options={})
+    options.merge!({:basic_auth => @auth})
+    options.merge!({:query => {:user => user}})
+    response = self.class.get("/signatures.json", options)
+    unless response.ok?
+      raise ApiError, "CLA API Error: #{[*response['errors']].join(', ')}"
+    end
+    if time_str = response['signed_cla_at']
+      Time.parse(time_str)
+    end
+  end
+end
+end

--- a/lib/puppet_labs/cla_mix.rb
+++ b/lib/puppet_labs/cla_mix.rb
@@ -1,0 +1,23 @@
+require 'puppet_labs/cla_api'
+
+module PuppetLabs
+module ClaMix
+  def cla_api
+    @cla_api ||= PuppetLabs::ClaAPI.new(:env => env)
+  end
+
+  def cla_enabled?
+    cla_api.enabled?
+  end
+
+  ##
+  # signed_time
+  #
+  # @param [String] user The user id of the contributor.
+  #
+  # @return [Time, nil] Time the CLA was signed or nil if not signed
+  def signed_time(user)
+    cla_api.signed_cla_at(user)
+  end
+end
+end

--- a/lib/puppet_labs/pull_request.rb
+++ b/lib/puppet_labs/pull_request.rb
@@ -1,10 +1,13 @@
 require 'json'
 require 'puppet_labs/github_mix'
+require 'puppet_labs/cla_mix'
 
 # This class provides a model of a pull rquest.
 module PuppetLabs
 class PullRequest
   include GithubMix
+  include ClaMix
+
   # Pull request data
   attr_reader :number,
     :env,

--- a/lib/puppet_labs/trello_pull_request_job.rb
+++ b/lib/puppet_labs/trello_pull_request_job.rb
@@ -1,5 +1,6 @@
 require 'puppet_labs/base_trello_job'
 require 'puppet_labs/pull_request'
+require 'chronic_duration'
 
 module PuppetLabs
   ##
@@ -11,23 +12,43 @@ module PuppetLabs
 class TrelloPullRequestJob < BaseTrelloJob
   attr_accessor :pull_request
 
+  def cla_status(pr)
+    # The CLA status of the PR author
+    if cla_signed_time = pr.signed_time(pr.author)
+      age_num = Time.now - cla_signed_time
+      age = ChronicDuration.output(age_num, :units => 2)
+      "CLA Status (PR Author): **SIGNED** #{age} ago"
+    else
+      "CLA Status (PR Author): **NOT SIGNED**"
+    end
+  rescue PuppetLabs::ClaAPI::ApiError => detail
+    "CLA Status (PR Author): **[UNKNOWN](https://cla.puppetlabs.com/admin/users?q=#{pr.author}&commit=Search)**"
+  end
+
   def card_body
     pr = pull_request
+
     str = [ 'Contributor Information',
             '----',
             '',
             "![#{pr.author_name}](#{pr.author_avatar_url})",
             '',
-            " * Author: **#{pr.author_name}** <#{pr.author_email}>",
-            " * Company: #{pr.author_company}",
-            " * Github ID: [#{pr.author}](#{pr.author_html_url})",
-            " * [Pull Request #{pr.number} Discussion](#{pr.html_url})",
-            " * [File Diff](#{pr.html_url}/files)",
-            '',
-            'Pull Request',
-            '====',
-            pr.body,
-    ].join("\n")
+            " * Author: **#{pr.author_name}** <#{pr.author_email}>"
+    ].join("\n") << "\n"
+
+    if pr.cla_enabled?
+      str << " * #{cla_status(pr)}\n"
+    end
+
+    str << [ " * Company: #{pr.author_company}",
+             " * Github ID: [#{pr.author}](#{pr.author_html_url})",
+             " * [Pull Request #{pr.number} Discussion](#{pr.html_url})",
+             " * [File Diff](#{pr.html_url}/files)",
+             '',
+             'Pull Request',
+             '====',
+             pr.body,
+    ].join("\n") << "\n"
   end
 
   def card_identifier


### PR DESCRIPTION
Without this patch we're not using the CLA app located at
https://cla.puppetlabs.com/api/v1/ to check the status of the CLA
signature for the pull request contributor.

This patch addresses the problem by adding three new configuration
environment variables, `CLA_STATUS_CHECK`, `CLA_API_USERNAME`, and
`CLA_API_PASSWORD`.  If `CLA_STATUS_CHECK` is the string 'true' then the
CLA API will be consulted using the github user id of the pull request
author.
